### PR TITLE
feat: can test Tower is well configured with `mix tower.test` or `Tower.test/0`

### DIFF
--- a/lib/mix/tasks/tower.test.ex
+++ b/lib/mix/tasks/tower.test.ex
@@ -1,0 +1,12 @@
+defmodule Mix.Tasks.Tower.Test do
+  @shortdoc "Generates a runtime exception to test Tower is well configured"
+
+  use Mix.Task
+
+  @requirements ["app.start"]
+
+  @impl true
+  def run(_args) do
+    Tower.test()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,7 @@ defmodule Tower.MixProject do
       deps: deps(),
       package: package(),
       dialyzer: [
+        plt_add_apps: [:mix],
         plt_local_path: "plts"
       ],
 


### PR DESCRIPTION
closes #63 

Second take on this.
Supersedes #64.
Won't mess with the `handle_*` functions result for now.