### PR TITLE
build(deps): no longer need to specify optional requirement on plug

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,6 @@ defmodule Tower.MixProject do
       {:uuid_v7, "~> 0.6.0"},
 
       # Optional
-      {:plug, "~> 1.0", optional: true},
       {:bandit, "~> 1.6", optional: true},
 
       # Dev


### PR DESCRIPTION
This stopped being necessary after we removed use of `Plug.Exception` in https://github.com/mimiquate/tower/commit/f93834398dc197d026311bfd9e335c3fba732316#diff-53f707a6c2182bd39db5e31797f28cc260899cc884bed85ad4d591ac2d6bb400L72