### PR TITLE
fix: honors log event message formatting from `report_cb`

### DIFF
--- a/lib/tower/logger_handler.ex
+++ b/lib/tower/logger_handler.ex
@@ -102,7 +102,7 @@ defmodule Tower.LoggerHandler do
   end
 
   defp handle_log_event(
-         %{level: level, msg: {:report, %{args: args, label: {:error_logger, _}, format: format}}} =
+         %{level: level, msg: {:report, %{label: {:error_logger, _}, format: format, args: args}}} =
            log_event
        ) do
     if should_handle?(level) do

--- a/lib/tower/logger_handler.ex
+++ b/lib/tower/logger_handler.ex
@@ -159,8 +159,14 @@ defmodule Tower.LoggerHandler do
     report_cb.(report, %{})
   end
 
-  defp formatted_report(report, _meta) do
+  defp formatted_report(%{} = report, _meta) do
     report
+    |> Map.to_list()
+    |> Kernel.inspect()
+  end
+
+  defp formatted_report(report, _meta) do
+    Kernel.inspect(report)
   end
 
   defp formatted_fa({format, args}) do

--- a/lib/tower/logger_handler.ex
+++ b/lib/tower/logger_handler.ex
@@ -102,10 +102,8 @@ defmodule Tower.LoggerHandler do
   end
 
   defp handle_log_event(
-         %{
-           level: level,
-           msg: {:report, %{args: args, label: {:error_logger, :error_msg}, format: format}}
-         } = log_event
+         %{level: level, msg: {:report, %{args: args, label: {:error_logger, _}, format: format}}} =
+           log_event
        ) do
     if should_handle?(level) do
       report_message(level, formatted_message(format, args), log_event)

--- a/lib/tower/logger_handler.ex
+++ b/lib/tower/logger_handler.ex
@@ -101,6 +101,17 @@ defmodule Tower.LoggerHandler do
     end
   end
 
+  defp handle_log_event(
+         %{
+           level: level,
+           msg: {:report, %{args: args, label: {:error_logger, :error_msg}, format: format}}
+         } = log_event
+       ) do
+    if should_handle?(level) do
+      report_message(level, formatted_message(format, args), log_event)
+    end
+  end
+
   defp handle_log_event(%{level: level, msg: {:report, report}} = log_event) do
     if should_handle?(level) do
       report_message(level, report, log_event)

--- a/test/tower_test.exs
+++ b/test/tower_test.exs
@@ -289,7 +289,7 @@ defmodule TowerTest do
     assert recent_datetime?(datetime)
   end
 
-  test "reports a Logger structured report" do
+  test "reports a Logger report list" do
     in_unlinked_process(fn ->
       require Logger
 
@@ -305,7 +305,34 @@ defmodule TowerTest do
           datetime: datetime,
           level: :critical,
           kind: :message,
-          reason: [something: :reported, this: :critical],
+          reason: "[something: :reported, this: :critical]",
+          stacktrace: nil,
+          by: Tower.LoggerHandler
+        }
+      ] = reported_events()
+    )
+
+    assert String.length(id) == 36
+    assert recent_datetime?(datetime)
+  end
+
+  test "reports a Logger report map (as a list as Elixir's Logger)" do
+    in_unlinked_process(fn ->
+      require Logger
+
+      capture_log(fn ->
+        Logger.critical(%{one: 1, two: 2})
+      end)
+    end)
+
+    assert_eventually(
+      [
+        %{
+          id: id,
+          datetime: datetime,
+          level: :critical,
+          kind: :message,
+          reason: "[one: 1, two: 2]",
           stacktrace: nil,
           by: Tower.LoggerHandler
         }


### PR DESCRIPTION
closes #170 

Properly formats log message of type "report" that come with a `report_cb` key in the metadata.

For example, the messages coming from:

- [`error_logger:error_msg/2`](https://www.erlang.org/doc/apps/kernel/error_logger.html#error_msg/2)
- [`error_logger:warning_msg/2`](https://www.erlang.org/doc/apps/kernel/error_logger.html#warning_msg/2)
- [`error_logger:info_msg/2`](https://www.erlang.org/doc/apps/kernel/error_logger.html#info_msg/2)

More details on `report_cb`:
- https://www.erlang.org/doc/apps/kernel/logger_chapter#log-message