### PR TITLE
test: covers GenServer stops

### DIFF
--- a/test/support/test_gen_server.ex
+++ b/test/support/test_gen_server.ex
@@ -7,7 +7,7 @@ defmodule TestGenServer do
   end
 
   @impl true
-  def handle_call(:stop, _from, state) do
-    {:stop, :error_in_call, state}
+  def handle_call({:stop, reason}, _from, state) do
+    {:stop, reason, state}
   end
 end

--- a/test/tower_test.exs
+++ b/test/tower_test.exs
@@ -250,7 +250,7 @@ defmodule TowerTest do
       in_unlinked_process(fn ->
         {:ok, pid} = GenServer.start(TestGenServer, [])
         # Client also raises because it doesn't receive a response from call
-        GenServer.call(pid, :stop)
+        GenServer.call(pid, {:stop, :abnormal})
       end)
     end)
 
@@ -260,7 +260,7 @@ defmodule TowerTest do
         %{
           level: :error,
           kind: :exit,
-          reason: {:error_in_call, {GenServer, :call, [_pid, :stop, 5000]}},
+          reason: {:abnormal, {GenServer, :call, _args}},
           stacktrace: [_ | _],
           by: Tower.LoggerHandler
         },
@@ -268,7 +268,7 @@ defmodule TowerTest do
         %{
           level: :error,
           kind: :exit,
-          reason: :error_in_call,
+          reason: :abnormal,
           stacktrace: [],
           by: Tower.LoggerHandler
         }


### PR DESCRIPTION
Read there are some changes coming in Elixir 1.19 (https://github.com/elixir-lang/elixir/pull/14380) that are related to the log event translation of GenServer stops/termination.

I don't think there's be any break for Tower, but still, better be specifically covered in the tests before that.