### PR TITLE
feat: richer gen server terminate events

### DIFF
--- a/lib/tower/event.ex
+++ b/lib/tower/event.ex
@@ -136,7 +136,7 @@ defmodule Tower.Event do
       metadata:
         %{application: application_data_from_log_event(log_event)}
         |> Map.merge(maybe_process_label())
-        |> Map.merge(maybe_log_event_report_label(log_event))
+        |> Map.merge(maybe_log_event_report(log_event))
         |> Map.merge(logger_metadata(log_event))
         |> Map.merge(Keyword.get(options, :metadata, %{})),
       by: Keyword.get(options, :by)
@@ -169,11 +169,11 @@ defmodule Tower.Event do
     %{}
   end
 
-  defp maybe_log_event_report_label(%{msg: {:report, %{label: label}}}) do
-    %{log_event_report_label: label}
+  defp maybe_log_event_report(%{msg: {:report, report}}) when is_map(report) do
+    %{log_event_report: Map.take(report, [:label, :last_message, :name])}
   end
 
-  defp maybe_log_event_report_label(_), do: %{}
+  defp maybe_log_event_report(_), do: %{}
 
   defp logger_metadata(log_event) do
     (log_event[:meta] || %{})

--- a/test/tower/gen_server_test.exs
+++ b/test/tower/gen_server_test.exs
@@ -33,7 +33,13 @@ defmodule TowerGenServerTest do
     )
 
     if Version.match?(System.version(), ">= 1.19.0") do
-      assert %{log_event_report_label: {:gen_server, :terminate}} = metadata
+      assert %{
+               log_event_report: %{
+                 label: {:gen_server, :terminate},
+                 name: _pid,
+                 last_message: {:"$gen_cast", {:raise, "something"}}
+               }
+             } = metadata
     end
   end
 
@@ -61,7 +67,7 @@ defmodule TowerGenServerTest do
     )
 
     if Version.match?(System.version(), ">= 1.19.0") do
-      assert %{log_event_report_label: {:gen_server, :terminate}} = metadata
+      assert %{log_event_report: %{label: {:gen_server, :terminate}}} = metadata
     end
   end
 
@@ -120,7 +126,7 @@ defmodule TowerGenServerTest do
     )
 
     if Version.match?(System.version(), ">= 1.19.0") do
-      assert %{log_event_report_label: {:gen_server, :terminate}} = metadata
+      assert %{log_event_report: %{label: {:gen_server, :terminate}}} = metadata
     end
   end
 
@@ -146,7 +152,13 @@ defmodule TowerGenServerTest do
     )
 
     if Version.match?(System.version(), ">= 1.19.0") do
-      assert %{log_event_report_label: {:gen_server, :terminate}} = metadata
+      assert %{
+               log_event_report: %{
+                 label: {:gen_server, :terminate},
+                 name: _pid,
+                 last_message: {:"$gen_cast", {:stop, :abnormal}}
+               }
+             } = metadata
     end
   end
 
@@ -172,7 +184,7 @@ defmodule TowerGenServerTest do
     )
 
     if Version.match?(System.version(), ">= 1.19.0") do
-      assert %{log_event_report_label: {:gen_server, :terminate}} = metadata
+      assert %{log_event_report: %{label: {:gen_server, :terminate}}} = metadata
     end
   end
 
@@ -209,8 +221,10 @@ defmodule TowerGenServerTest do
     )
 
     if Version.match?(System.version(), ">= 1.19.0") do
-      assert %{log_event_report_label: {Task.Supervisor, :terminating}} = client_event_metadata
-      assert %{log_event_report_label: {:gen_server, :terminate}} = server_event_metadata
+      assert %{log_event_report: %{label: {Task.Supervisor, :terminating}}} =
+               client_event_metadata
+
+      assert %{log_event_report: %{label: {:gen_server, :terminate}}} = server_event_metadata
     end
   end
 


### PR DESCRIPTION
closes #181 

Helps contextualize which exceptions are coming from, e.g. a GenServer being terminated in case it's set to `{:gen_server, :terminate}` among a few other labels.